### PR TITLE
商品削除機能実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -38,8 +38,8 @@ class ItemsController < ApplicationController
   def destroy
     if @item.user == current_user
        @item.destroy
-       redirect_to root_path
     end
+       redirect_to root_path
   end
   
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -36,9 +36,10 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    @item.user == current_user
-    @item.destroy
-    redirect_to root_path
+    if @item.user == current_user
+       @item.destroy
+       redirect_to root_path
+    end
   end
   
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy ]
 
   def index
     @items = Item.all.order(created_at: :desc)
@@ -34,6 +34,13 @@ class ItemsController < ApplicationController
      render :edit
    end
   end
+
+  def destroy
+    @item.user == current_user
+    @item.destroy
+    redirect_to root_path
+  end
+  
 
   
   private

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
     <% if current_user == @item.user%>
     <%= link_to "商品の編集",  edit_item_path, method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+    <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
 
     
     <% else  %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create, :show, :edit, :update ]
+  resources :items, only: [:index, :new, :create, :show, :edit, :update, :destroy ]
 end


### PR DESCRIPTION
# what
商品削除機能作成

# why
商品削除機能実装のため

# 動画
 ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/95a591aaad58c2d4a9ad6f4cb8d084af

わかりにくい文章を送ってしまい、申し訳ありません。再度ご確認よろしくお願いいたします。